### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Created a basic Express server with a mock activity feed endpoint.

### What changed?

- Implemented a new Express server in `server.js`
- Added a `/feed` endpoint that returns mock activity feed data
- Included sample activity feed entries with various types of user actions

### How to test?

1. Install dependencies: `npm install express`
2. Start the server: `node server.js`
3. Access the endpoint: `curl http://localhost:3000/feed`
4. Verify that the response contains the mock activity feed data

### Why make this change?

This change sets up the foundation for a backend service that will provide activity feed data to the frontend. It allows for initial testing and integration of the activity feed feature without requiring a full database implementation.

---

